### PR TITLE
[FIX] - Coding style, There must not be a space before the colon in a return type declaration

### DIFF
--- a/src/Utils/StringUtils.php
+++ b/src/Utils/StringUtils.php
@@ -16,6 +16,6 @@ class StringUtils
             throw new RuntimeException(sprintf('Failed to parse id from link %s', $link));
         }
 
-        return (int)end($linkParts);
+        return (int) end($linkParts);
     }
 }


### PR DESCRIPTION
Just a small fix that makes composer cs clean :)